### PR TITLE
Fix duplicate `InputSizeLimit` warnings per file

### DIFF
--- a/src/CustomCode-Analyzer/Analyzer.cs
+++ b/src/CustomCode-Analyzer/Analyzer.cs
@@ -849,8 +849,6 @@ namespace CustomCode_Analyzer
             var syntaxRef = methodSymbol.DeclaringSyntaxReferences.FirstOrDefault();
             if (syntaxRef is null)
                 return;
-            if (syntaxRef.GetSyntax() is not MethodDeclarationSyntax methodSyntax)
-                return;
 
             var containingType = methodSymbol.ContainingType;
 

--- a/src/CustomCode-Analyzer/Analyzer.cs
+++ b/src/CustomCode-Analyzer/Analyzer.cs
@@ -838,7 +838,11 @@ namespace CustomCode_Analyzer
         /// <summary>
         /// Analyzes method declarations.
         /// <summary>
-        private static void AnalyzeMethod(SymbolAnalysisContext context, IMethodSymbol methodSymbol, ConcurrentDictionary<SyntaxTree, bool> reportedInputSizeLimitDiagnostics)
+        private static void AnalyzeMethod(
+            SymbolAnalysisContext context,
+            IMethodSymbol methodSymbol,
+            ConcurrentDictionary<SyntaxTree, bool> reportedInputSizeLimitDiagnostics
+        )
         {
             var syntaxRef = methodSymbol.DeclaringSyntaxReferences.FirstOrDefault();
             if (syntaxRef is null)
@@ -902,14 +906,23 @@ namespace CustomCode_Analyzer
                         }
                     }
 
-                    if (parameter.Type is IArrayTypeSymbol arrayType &&
-                        arrayType.ElementType.SpecialType == SpecialType.System_Byte)
+                    if (
+                        parameter.Type is IArrayTypeSymbol arrayType
+                        && arrayType.ElementType.SpecialType == SpecialType.System_Byte
+                    )
                     {
-                        var parameterSyntax = parameter.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as ParameterSyntax;
+                        var parameterSyntax =
+                            parameter.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                            as ParameterSyntax;
                         if (parameterSyntax?.Type != null)
                         {
                             var diagnosticLocation = parameterSyntax.Type.GetLocation();
-                            if (reportedInputSizeLimitDiagnostics.TryAdd(parameterSyntax.SyntaxTree, true))
+                            if (
+                                reportedInputSizeLimitDiagnostics.TryAdd(
+                                    parameterSyntax.SyntaxTree,
+                                    true
+                                )
+                            )
                             {
                                 context.ReportDiagnostic(
                                     Diagnostic.Create(InputSizeLimitRule, diagnosticLocation)

--- a/tests/CustomCode-Analyzer.Tests/AnalyzerTests.cs
+++ b/tests/CustomCode-Analyzer.Tests/AnalyzerTests.cs
@@ -1908,7 +1908,7 @@ public class Calculator : ICalculator
 
         // --------------------- InputSizeLimitRule --------------------------------
         [TestMethod]
-        public async Task InputSizeLimitRule_ShowsInfo()
+        public async Task InputSizeLimitRule_ReportsOnlyOneWarningForMultipleMethods()
         {
             var test =
                 @"
@@ -1917,19 +1917,22 @@ namespace TestNamespace
     [OSInterface]
     public interface IDocumentProcessor
     {
-        void ProcessDocument(byte[] documentData);
-        void ProcessMetadata(string metadata);
+         void ProcessDocument(byte[] documentData);
+         void ProcessAnotherDocument(byte[] otherData);
+         void ProcessMetadata(string metadata);
     }
 
     public class DocumentProcessor : IDocumentProcessor
     {
-        public void ProcessDocument(byte[] documentData) { }
-        public void ProcessMetadata(string metadata) { }
+         public void ProcessDocument(byte[] documentData) { }
+         public void ProcessAnotherDocument(byte[] otherData) { }
+         public void ProcessMetadata(string metadata) { }
     }
 }";
+            // Expect only one diagnostic (highlighting the "byte[]" in the first method)
             var expected = CSharpAnalyzerVerifier<Analyzer>
                 .Diagnostic(DiagnosticIds.InputSizeLimit)
-                .WithSpan(7, 9, 7, 51);
+                .WithSpan(7, 31, 7, 37);
 
             await CSharpAnalyzerVerifier<Analyzer>.VerifyAnalyzerAsync(
                 test,

--- a/tests/CustomCode-Analyzer.Tests/AnalyzerTests.cs
+++ b/tests/CustomCode-Analyzer.Tests/AnalyzerTests.cs
@@ -1917,22 +1917,22 @@ namespace TestNamespace
     [OSInterface]
     public interface IDocumentProcessor
     {
-         void ProcessDocument(byte[] documentData);
-         void ProcessAnotherDocument(byte[] otherData);
-         void ProcessMetadata(string metadata);
+        void ProcessDocument(byte[] documentData);
+        void ProcessAnotherDocument(byte[] otherData);
+        void ProcessMetadata(string metadata);
     }
 
     public class DocumentProcessor : IDocumentProcessor
     {
-         public void ProcessDocument(byte[] documentData) { }
-         public void ProcessAnotherDocument(byte[] otherData) { }
-         public void ProcessMetadata(string metadata) { }
+        public void ProcessDocument(byte[] documentData) { }
+        public void ProcessAnotherDocument(byte[] otherData) { }
+        public void ProcessMetadata(string metadata) { }
     }
 }";
             // Expect only one diagnostic (highlighting the "byte[]" in the first method)
             var expected = CSharpAnalyzerVerifier<Analyzer>
                 .Diagnostic(DiagnosticIds.InputSizeLimit)
-                .WithSpan(7, 31, 7, 37);
+                .WithSpan(7, 30, 7, 36);
 
             await CSharpAnalyzerVerifier<Analyzer>.VerifyAnalyzerAsync(
                 test,


### PR DESCRIPTION
  Fixes https://github.com/jonathanalgar/CustomCode-Analyzer/issues/26