### PR TITLE
Exclude `out` parameters from pass-by-reference diagnostics

### DIFF
--- a/src/CustomCode-Analyzer/Analyzer.cs
+++ b/src/CustomCode-Analyzer/Analyzer.cs
@@ -887,8 +887,8 @@ namespace CustomCode_Analyzer
             {
                 foreach (var parameter in methodSymbol.Parameters)
                 {
-                    // Disallow reference-like (ref/out/in) parameters
-                    if (parameter.RefKind is RefKind.Ref or RefKind.Out or RefKind.In)
+                    // Disallow reference-like (ref/in) parameters
+                    if (parameter.RefKind is RefKind.Ref or RefKind.In)
                     {
                         var paramSyntax =
                             parameter.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()

--- a/tests/CustomCode-Analyzer.Tests/AnalyzerTests.cs
+++ b/tests/CustomCode-Analyzer.Tests/AnalyzerTests.cs
@@ -1165,10 +1165,6 @@ public class TestImplementation : ITestInterface
                     .WithArguments("value", "UpdateValue"),
                 CSharpAnalyzerVerifier<Analyzer>
                     .Diagnostic(DiagnosticIds.ParameterByReference)
-                    .WithSpan(6, 19, 6, 34)
-                    .WithArguments("text", "GetValue"),
-                CSharpAnalyzerVerifier<Analyzer>
-                    .Diagnostic(DiagnosticIds.ParameterByReference)
                     .WithSpan(7, 20, 7, 36)
                     .WithArguments("number", "ReadValue"),
             };
@@ -1213,10 +1209,6 @@ namespace Implementation
                     .Diagnostic(DiagnosticIds.ParameterByReference)
                     .WithSpan(7, 26, 7, 39)
                     .WithArguments("value", "UpdateValue"),
-                CSharpAnalyzerVerifier<Analyzer>
-                    .Diagnostic(DiagnosticIds.ParameterByReference)
-                    .WithSpan(8, 23, 8, 38)
-                    .WithArguments("text", "GetValue"),
                 CSharpAnalyzerVerifier<Analyzer>
                     .Diagnostic(DiagnosticIds.ParameterByReference)
                     .WithSpan(9, 24, 9, 40)


### PR DESCRIPTION
[Documentation](https://success.outsystems.com/documentation/outsystems_developer_cloud/errors/external_libraries_sdk_errors/os_elg_modl_05016/) not clear—will propose an update.